### PR TITLE
I've updated the code to automatically start the vocabulary practice …

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,10 +14,10 @@ type Level = 'A1' | 'A2' | 'B1' | 'B2'
 
 // Define the structure of the imported vocabulary data
 interface VocabularyData {
-  A1: { id: string; wort: string; bedeutung: string }[]
-  A2: { id: string; wort: string; bedeutung: string }[]
-  B1: { id: string; wort: string; bedeutung: string }[]
-  B2: { id: string; wort: string; bedeutung: string }[]
+  A1: { wort: string; bedeutung: string }[]
+  A2: { wort: string; bedeutung: string }[]
+  B1: { wort: string; bedeutung: string }[]
+  B2: { wort: string; bedeutung: string }[]
 }
 
 const getStorageKey = (level: Level) => `schnelllern-vocabulary-${level}`
@@ -27,6 +27,7 @@ function App() {
   const [currentWord, setCurrentWord] = useState<VocabularyItem | null>(null)
   const [showAnswer, setShowAnswer] = useState(false)
   const [selectedLevel, setSelectedLevel] = useState<Level>('B2')
+  const [shouldStartPractice, setShouldStartPractice] = useState(false)
 
   // Load vocabulary from localStorage or default data
   useEffect(() => {
@@ -38,7 +39,7 @@ function App() {
       // Load default vocabulary from vocabulary.json file for selected level
       const levelVocabulary = (vocabularyData as VocabularyData)[selectedLevel] || []
       const defaultVocabulary: VocabularyItem[] = levelVocabulary.map((item) => ({
-        id: item.id,
+        id: item.wort,
         wort: item.wort,
         bedeutung: item.bedeutung,
         mastered: false
@@ -52,11 +53,21 @@ function App() {
     localStorage.setItem(getStorageKey(selectedLevel), JSON.stringify(vocabulary))
   }, [vocabulary, selectedLevel])
 
+  useEffect(() => {
+    if (shouldStartPractice && vocabulary.length > 0) {
+      startPractice()
+      setShouldStartPractice(false)
+    }
+  }, [vocabulary, shouldStartPractice])
+
   // Load vocabulary for selected level
   const loadLevelVocabulary = (level: Level) => {
     setSelectedLevel(level)
     setCurrentWord(null)
     setShowAnswer(false)
+    if (level === 'B2') {
+      setShouldStartPractice(true)
+    }
   }
 
   // Get random word for practice


### PR DESCRIPTION
…when you select the B2 level. This is based on my interpretation of your request to have the vocabulary "looked at" when B2 is clicked.

Additionally, I fixed a bug where vocabulary items were being created without a unique `id`, which could lead to issues with React's rendering. The vocabulary word (`wort`) is now used as the `id`.

Changes:
- Added `shouldStartPractice` state to `App.tsx` to control when to start the practice.
- Modified `loadLevelVocabulary` to set `shouldStartPractice` to `true` for the B2 level.
- Added a `useEffect` to trigger `startPractice` when the conditions are met.
- Fixed the `id` assignment for vocabulary items to use `item.wort`.
- Updated the `VocabularyData` interface to match the structure of the JSON data.