### PR TITLE
fix: Ensure B2 vocabulary is displayed correctly

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,10 +14,10 @@ type Level = 'A1' | 'A2' | 'B1' | 'B2'
 
 // Define the structure of the imported vocabulary data
 interface VocabularyData {
-  A1: { id: string; wort: string; bedeutung: string }[]
-  A2: { id: string; wort: string; bedeutung: string }[]
-  B1: { id: string; wort: string; bedeutung: string }[]
-  B2: { id: string; wort: string; bedeutung: string }[]
+  A1: { id?: string; wort: string; bedeutung: string }[]
+  A2: { id?: string; wort: string; bedeutung: string }[]
+  B1: { id?: string; wort: string; bedeutung: string }[]
+  B2: { id?: string; wort: string; bedeutung: string }[]
 }
 
 const getStorageKey = (level: Level) => `schnelllern-vocabulary-${level}`
@@ -37,8 +37,8 @@ function App() {
     } else {
       // Load default vocabulary from vocabulary.json file for selected level
       const levelVocabulary = (vocabularyData as VocabularyData)[selectedLevel] || []
-      const defaultVocabulary: VocabularyItem[] = levelVocabulary.map((item) => ({
-        id: item.id,
+      const defaultVocabulary: VocabularyItem[] = levelVocabulary.map((item, index) => ({
+        id: item.id || `${selectedLevel}-${item.wort}-${index}`,
         wort: item.wort,
         bedeutung: item.bedeutung,
         mastered: false


### PR DESCRIPTION
The B2 vocabulary list was not being displayed because the vocabulary items in the JSON data were missing the `id` property, which the application requires.

This change makes the application more robust by:
1. Making the `id` property optional in the `VocabularyData` interface.
2. Generating a unique and stable `id` for any vocabulary item that doesn't have one when the data is loaded.

This ensures that the B2 vocabulary and any future vocabulary lists without pre-assigned IDs will be handled correctly.