### PR TITLE
fix(app): Allow reloading the current vocabulary level

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -71,7 +71,6 @@ function App() {
 
   // Load vocabulary for selected level
   const loadLevelVocabulary = (level: Level) => {
-    if (level === selectedLevel) return
     setIsLoaded(false)
     setSelectedLevel(level)
     setCurrentWord(null)


### PR DESCRIPTION
Previously, the `loadLevelVocabulary` function would exit immediately if the selected level was clicked again. This prevented you from resetting the practice for the current level.

The initial check `if (level === selectedLevel) return` has been removed. Now, clicking on any level button, including the active one, will correctly reload the vocabulary and reset the practice state.