### PR TITLE
I've fixed the issue where the B2 vocabulary was not loading on refre…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,35 +29,37 @@ function App() {
   const [selectedLevel, setSelectedLevel] = useState<Level>('B2')
   const [isLoaded, setIsLoaded] = useState(false)
 
+  const loadDefaultVocabulary = (level: Level): VocabularyItem[] => {
+    const data = (vocabularyData as any).default || vocabularyData;
+    const levelVocabulary = (data as VocabularyData)[level] || [];
+    return levelVocabulary.map((item, index) => ({
+      id: item.id || `${level}-${item.wort}-${index}`,
+      wort: item.wort,
+      bedeutung: item.bedeutung,
+      mastered: false
+    }));
+  };
+
   // Load vocabulary from localStorage or default data
   useEffect(() => {
     const storageKey = getStorageKey(selectedLevel)
     const saved = localStorage.getItem(storageKey)
     if (saved) {
       try {
-        setVocabulary(JSON.parse(saved))
+        const parsed = JSON.parse(saved);
+        const defaultVocab = loadDefaultVocabulary(selectedLevel);
+        // Load from default if localStorage is empty but default has words
+        if (parsed.length === 0 && defaultVocab.length > 0) {
+          setVocabulary(defaultVocab);
+        } else {
+          setVocabulary(parsed);
+        }
       } catch (e) {
         console.error("Failed to parse vocabulary from local storage", e)
-        // Fallback to default if parsing fails
-        const levelVocabulary = (vocabularyData as VocabularyData)[selectedLevel] || []
-        const defaultVocabulary: VocabularyItem[] = levelVocabulary.map((item, index) => ({
-          id: item.id || `${selectedLevel}-${item.wort}-${index}`,
-          wort: item.wort,
-          bedeutung: item.bedeutung,
-          mastered: false
-        }))
-        setVocabulary(defaultVocabulary)
+        setVocabulary(loadDefaultVocabulary(selectedLevel));
       }
     } else {
-      // Load default vocabulary from vocabulary.json file for selected level
-      const levelVocabulary = (vocabularyData as VocabularyData)[selectedLevel] || []
-      const defaultVocabulary: VocabularyItem[] = levelVocabulary.map((item, index) => ({
-        id: item.id || `${selectedLevel}-${item.wort}-${index}`,
-        wort: item.wort,
-        bedeutung: item.bedeutung,
-        mastered: false
-      }))
-      setVocabulary(defaultVocabulary)
+      setVocabulary(loadDefaultVocabulary(selectedLevel));
     }
     setIsLoaded(true)
   }, [selectedLevel])


### PR DESCRIPTION
…sh or upon level selection.

I found that the vocabulary for the B2 level wasn't being loaded because of an issue with how the imported `vocabulary.json` data was being accessed. This resulted in an empty vocabulary list being displayed and saved to localStorage, causing the problem to persist.

To solve this, I introduced a helper function, `loadDefaultVocabulary`, to centralize and correct the loading logic. The data access is now more robust, handling potential variations in how JSON modules are imported.

I also improved the loading logic to recover from a 'poisoned' localStorage (where an empty array was stored for a level that should have words) by reloading the data from the source JSON file.